### PR TITLE
replace deprecated ggplot2::guides(... = FALSE)

### DIFF
--- a/R/ggheatmap.R
+++ b/R/ggheatmap.R
@@ -171,7 +171,7 @@
 #'   geom_point()+theme_classic()+
 #'   scale_color_manual(values = c("#D2691E","#1E87D2"))+
 #'   theme(line = element_blank(),axis.text = element_blank(),axis.title = element_blank())+
-#'   guides(size = FALSE)
+#'   guides(size = "none")
 #'
 #' p%>%insert_right(p1,width = 0.1)
 #'}


### PR DESCRIPTION
see https://github.com/tidyverse/ggplot2/issues/4097

This PR just changes the example. The deprecation warning that is currently still shown when using ggheatmap is already fixed upstream: https://github.com/talgalili/dendextend/pull/107